### PR TITLE
### Summary of Important Changes

### DIFF
--- a/audit_log.h
+++ b/audit_log.h
@@ -1,1 +1,19 @@
-#pragma once
+#ifndef AUDIT_LOG_H
+#define AUDIT_LOG_H
+
+#include "header_lib.h"
+
+namespace password_manager_ns {
+
+    class audit_log {
+    public:
+        void log_action(const string& username, const string& action);
+        vector<string> get_log() const;
+
+    private:
+        vector<string> log_entries;
+    };
+
+}
+
+#endif

--- a/backup_manager.h
+++ b/backup_manager.h
@@ -1,1 +1,16 @@
-#pragma once
+#ifndef BACKUP_MANAGER_H
+#define BACKUP_MANAGER_H
+
+#include "header_lib.h"
+
+namespace password_manager_ns {
+
+    class backup_manager {
+    public:
+        bool create_backup(const string& file_path);
+        bool load_backup(const string& file_path);
+    };
+
+}
+
+#endif

--- a/category_manager.h
+++ b/category_manager.h
@@ -1,1 +1,19 @@
-#pragma once
+#ifndef CATEGORY_MANAGER_H
+#define CATEGORY_MANAGER_H
+
+#include "header_lib.h"
+
+namespace password_manager_ns {
+
+    class category_manager {
+    public:
+        void add_category(const string& category_name);
+        void remove_category(const string& category_name);
+        bool category_exists(const string& category_name) const;
+
+    private:
+        map<string, vector<string>> categories;
+    };
+}
+
+#endif


### PR DESCRIPTION
The code changes primarily involve updating header files to replace `#pragma once` with traditional include guards, including a common header file, and defining new classes within a specific namespace. These changes enhance the modularity and organization of the codebase, ensuring proper inclusion of header files and encapsulating functionality within classes.

### List of Changes
1. **Replacement of `#pragma once` with Include Guards**:
   - The `#pragma once` directive has been replaced with traditional include guards in the header files `audit_log.h`, `backup_manager.h`, and `category_manager.h`. This involves adding `#ifndef`, `#define`, and `#endif` preprocessor directives to prevent multiple inclusions of the same header file.
   - **References**: `audit_log.h`, `backup_manager.h`, `category_manager.h`

2. **Inclusion of `header_lib.h`**:
   - The `header_lib.h` header file has been included in each of the modified header files to ensure necessary dependencies are available.
   - **References**: `audit_log.h`, `backup_manager.h`, `category_manager.h`

3. **Definition of Classes within `password_manager_ns` Namespace**:
   - Each header file now defines a class within the `password_manager_ns` namespace: - `audit_log` class in `audit_log.h` with methods to log actions and retrieve log entries. - `backup_manager` class in `backup_manager.h` with methods to create and load backups. - `category_manager` class in `category_manager.h` with methods to add, remove, and check the existence of categories.
   - **References**: `audit_log.h`, `backup_manager.h`, `category_manager.h`

4. **Private Members in Classes**:
   - The `audit_log` class has a private member `log_entries` which is a vector of strings.
   - The `category_manager` class has a private member `categories` which is a map of strings to vectors of strings.
   - **References**: `audit_log.h`, `category_manager.h`